### PR TITLE
fix: allow directory access

### DIFF
--- a/packages/main/src/components/Footer.tsx
+++ b/packages/main/src/components/Footer.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { helloWorld } from "@foo/utils";
 
 const Footer: React.FC = () => (
-  <div className="mt-4">
+  <footer className="mt-4">
     {/* hello world */}
     {helloWorld()}
-  </div>
+  </footer>
 );
 
 export default Footer;

--- a/packages/main/vite.config.ts
+++ b/packages/main/vite.config.ts
@@ -7,4 +7,9 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   envDir: join(__dirname, "../.."),
   plugins: [tsconfigPaths({ root: ".." }), react()],
+  server: {
+    fs: {
+      allow: [join(__dirname, '..', 'utils')]
+    } 
+  }
 });


### PR DESCRIPTION
Hi, responding to https://github.com/cypress-io/cypress/issues/22422

I looked in the terminal and saw this:

```
GET /__cypress/src/src/components/Footer.cy.tsx 200 130.536 ms - -
GET /__cypress/src/src/components/Footer.tsx 200 3.395 ms - -
GET /__cypress/src/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=bc099cc2 200 2.137 ms - -
The request url "/Users/lachlan/code/dump/cypress-component-vite-issue/packages/utils/src/index.ts" is outside of Vite serving allow list.

- /Users/lachlan/code/dump/cypress-component-vite-issue/packages/main
- /Users/lachlan/code/dump/cypress-component-vite-issue/node_modules
- /Users/lachlan/Library/Caches/Cypress/10.1.0/Cypress.app/Contents/Resources/app

Refer to docs https://vitejs.dev/config/#server-fs-allow for configurations and more details.

GET /__cypress/src/@fs/Users/lachlan/code/dump/cypress-component-vite-issue/packages/utils/src/index.ts 403 7.489 ms - -
```

I was able to fix it by adding one level higher to the `fs.allow` list. You can read about this setting in the [Vite docs](https://vitejs.dev/config/#server-fs-allow).